### PR TITLE
Normalize namespaces so that metadata alias settings can be used

### DIFF
--- a/src/Cake.DocFx/Cake.DocFx.csproj
+++ b/src/Cake.DocFx/Cake.DocFx.csproj
@@ -46,15 +46,15 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Build\DocFxBuildRunner.cs" />
-    <Compile Include="Build\DocFxBuildSettings.cs" />
+    <Compile Include="DocFxBuildRunner.cs" />
+    <Compile Include="DocFxBuildSettings.cs" />
     <Compile Include="DocFxAliases.cs" />
     <Compile Include="DocFxRunner.cs" />
     <Compile Include="DocFxSettings.cs" />
     <Compile Include="DocFxTool.cs" />
     <Compile Include="Helper\Contract.cs" />
-    <Compile Include="Metadata\DocFxMetadataRunner.cs" />
-    <Compile Include="Metadata\DocFxMetadataSettings.cs" />
+    <Compile Include="DocFxMetadataRunner.cs" />
+    <Compile Include="DocFxMetadataSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.Static.cs" />
   </ItemGroup>

--- a/src/Cake.DocFx/DocFxAliases.cs
+++ b/src/Cake.DocFx/DocFxAliases.cs
@@ -2,9 +2,7 @@
 using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
-using Cake.DocFx.Build;
 using Cake.DocFx.Helper;
-using Cake.DocFx.Metadata;
 
 namespace Cake.DocFx
 {

--- a/src/Cake.DocFx/DocFxBuildRunner.cs
+++ b/src/Cake.DocFx/DocFxBuildRunner.cs
@@ -2,7 +2,7 @@
 using Cake.Core.IO;
 using Cake.DocFx.Helper;
 
-namespace Cake.DocFx.Build
+namespace Cake.DocFx
 {
     /// <summary>
     /// Commandline Runner for docfx build

--- a/src/Cake.DocFx/DocFxBuildSettings.cs
+++ b/src/Cake.DocFx/DocFxBuildSettings.cs
@@ -1,7 +1,7 @@
 ﻿using Cake.Core.IO;
 using Cake.Core.Tooling;
 
-namespace Cake.DocFx.Build
+namespace Cake.DocFx
 {
     /// <summary>
     /// Settings used for docfx build calls.

--- a/src/Cake.DocFx/DocFxMetadataRunner.cs
+++ b/src/Cake.DocFx/DocFxMetadataRunner.cs
@@ -2,7 +2,7 @@
 using Cake.Core;
 using Cake.Core.IO;
 
-namespace Cake.DocFx.Metadata
+namespace Cake.DocFx
 {
     /// <summary>
     /// Commandline runner for docfx metadata

--- a/src/Cake.DocFx/DocFxMetadataSettings.cs
+++ b/src/Cake.DocFx/DocFxMetadataSettings.cs
@@ -2,7 +2,7 @@
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
-namespace Cake.DocFx.Metadata
+namespace Cake.DocFx
 {
     /// <summary>
     ///     Settings used for docfx metadata


### PR DESCRIPTION
I noticed that the `DocFxBuild` and `DocFxMetadata` aliases couldn't be used properly unless you use the full namespace for the settings classes. I think bringing these aliases and their settings into the main namespace follows conventions used by other alises.

eg.

```csharp
DocFxBuild(file, new DocFxBuildSettings()
{
	OutputPath = docs
});
```